### PR TITLE
Pass WaitGroup by pointer without copying it

### DIFF
--- a/index.html
+++ b/index.html
@@ -1407,7 +1407,7 @@ func main() {
 
     for i := 0; i &lt; workerCount; i++ {
         wg.Add(1)
-        go doit(i,done,wg)
+        go doit(i,done,&amp;wg)
     }
 
     close(done)
@@ -1415,7 +1415,7 @@ func main() {
     fmt.Println("all done!")
 }
 
-func doit(workerId int,done &lt;-chan struct{},wg sync.WaitGroup) {  
+func doit(workerId int,done &lt;-chan struct{},wg *sync.WaitGroup) {  
     fmt.Printf("[%v] is running\n",workerId)
     defer wg.Done()
     &lt;- done


### PR DESCRIPTION
First of all, thanks for a nice article!


Without this fix, it does not work as expected:
```
$ go run .
[1] is running
[1] is done
[0] is running
[0] is done
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc0000900c0?)
        /usr/local/go/src/runtime/sema.go:62 +0x25
sync.(*WaitGroup).Wait(0xc0000200c0?)
        /usr/local/go/src/sync/waitgroup.go:116 +0x48
main.main()
        /home/hnakamur/go-waitgroup-copy-ok/main.go:19 +0xe6
exit status 2
```

go vet prints the following warnings.
```
go vet main.go
./main.go:15:20: call of doit copies lock value: sync.WaitGroup contains sync.noCopy
./main.go:23:50: doit passes lock by value: sync.WaitGroup contains sync.noCopy
```

With this fix, it works as expected:
```
$ go run .
[1] is running
[1] is done
[0] is running
[0] is done
all done!
```

